### PR TITLE
ISSUE #1, ISSUE #2: streaming input and output

### DIFF
--- a/onaws/cli.py
+++ b/onaws/cli.py
@@ -10,6 +10,13 @@ spec = {
             'action': 'store',
             'help': 'Input hostname / IP',
             'nargs': '?'
+        },
+        {
+            'options': ['-s'],
+            'dest': 'stream',
+            'action': 'store',
+            'choices': ['t', 'j'],
+            'help': 'stream output, t = text lines, j = json lines',
         }
     ],
     'epilog': "Examples:\n\
@@ -48,6 +55,7 @@ def sanitize(stream):
 def gather_input(args):
     hosts = sanitize(stream(args.input))
     return {
+        'stream': args.stream,
         'input': args.input,
         'hosts': hosts,
     }

--- a/onaws/cli.py
+++ b/onaws/cli.py
@@ -35,20 +35,18 @@ def create_parser(spec):
 parser = create_parser(spec)
 
 
-def get_raw_input(input_str):
-    if input_str is None:
-        return sys.stdin.read()
-
-    return input_str
+def stream(inp):
+    return [inp] if inp else iter(sys.stdin)
 
 
-def parse_raw_input(text):
-    return [line.strip() for line in text.strip().splitlines() if line.strip()]
+def sanitize(stream):
+    s = (line.strip() for line in stream)
+    s = (line for line in s if line)
+    return s
 
 
 def gather_input(args):
-    raw = get_raw_input(args.input)
-    hosts = parse_raw_input(raw)
+    hosts = sanitize(stream(args.input))
     return {
         'input': args.input,
         'hosts': hosts,

--- a/onaws/core.py
+++ b/onaws/core.py
@@ -96,10 +96,34 @@ def process(prefixes, args):
     for host in args['hosts']:
         print(f'Processing: {host}')
         results[host] = process_one(prefixes, host)
-    return json.dumps(dict(results), indent=4)
+    results = json.dumps(dict(results), indent=4)
+    print(results)
+
+
+t_cols = ['is_aws_ip', 'host', 'ip_address', 'service', 'region', 'matched_subnet']
+
+
+def t_row(host, result):
+    row = (str(result.get(col, '')) for col in t_cols)
+    return '\t'.join([host, *row])
+
+
+def j_row(host, result):
+    data = {'input': host, **result}
+    return json.dumps(data)
+
+
+
+def process_stream(prefixes, args):
+    func = globals()['{stream}_row'.format_map(args)]
+
+    for host in args['hosts']:
+        res = process_one(prefixes, host)
+        row = func(host, res)
+        print(row)
 
 
 def run(prefixes, args):
     # print(args['hosts'])
-    results = process(prefixes, args)
-    print(results)
+    f = process_stream if args['stream'] else process
+    f(prefixes, args)


### PR DESCRIPTION
* current changes stream the input, hence the processing should occur at constant memory
* However, as the output is still being gathered in-memory, the memory consumption on large input still remains; to be solved in issue #2.
* a optional parameter has been added `-s` that takes two values `t: text` or `j: json`
* with this change the whole process should run at constant memory
* Example Usage: `cat file.txt | onaws -sj`