### PR TITLE
Cache ip ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ If, for some reason, the tool fails to fetch the AWS IP ranges, it will throw th
 
 ```shell
 $ onaws
-Failed to get IP ranges from AWS
+Failed to get AWS IP ranges
 ```
 
 # Contribution

--- a/onaws/__main__.py
+++ b/onaws/__main__.py
@@ -4,7 +4,10 @@ def main():
     args = cli.parser.parse_args()
     args = cli.gather_input(args)
 
-    prefixes = ipranges.get_range_prefixes()
+    try:
+        prefixes = ipranges.get_range_prefixes()
+    except:
+        raise SystemExit('Failed to get AWS IP ranges')
 
     core.run(prefixes, args)
 

--- a/onaws/__main__.py
+++ b/onaws/__main__.py
@@ -1,10 +1,10 @@
-from . import cli, core
+from . import cli, core, ipranges
 
 def main():
     args = cli.parser.parse_args()
     args = cli.gather_input(args)
 
-    prefixes = core.get_range_prefixes()
+    prefixes = ipranges.get_range_prefixes()
 
     core.run(prefixes, args)
 

--- a/onaws/core.py
+++ b/onaws/core.py
@@ -2,18 +2,6 @@ import ipaddress
 import json
 import socket
 
-import requests
-
-AWS_IP_RANGES_URL = 'https://ip-ranges.amazonaws.com/ip-ranges.json'
-
-
-def get_range_prefixes():
-    try:
-        data = requests.get(AWS_IP_RANGES_URL, timeout=10).json()
-    except Exception:
-        raise SystemExit('Failed to get IP ranges from AWS')
-    return data['prefixes']
-
 
 def resolve(hostname):
     try:

--- a/onaws/ipranges.py
+++ b/onaws/ipranges.py
@@ -1,0 +1,49 @@
+import json
+import hashlib
+from pathlib import Path
+
+import requests
+
+AWS_IP_RANGES_URL = 'https://ip-ranges.amazonaws.com/ip-ranges.json'
+
+local_data_path = Path('~/.onaws/ip-ranges.json').expanduser()
+
+
+def get_remote_etag():
+    try:
+        return requests.head(AWS_IP_RANGES_URL, timeout=10).headers['etag'].strip('"')
+    except:
+        return None
+
+
+def get_remote_data():
+    return requests.get(AWS_IP_RANGES_URL, timeout=10).text
+
+
+def get_local_data():
+    try:
+        return local_data_path.read_text()
+    except FileNotFoundError:
+        return ""
+
+
+def save_local_data(data):
+    local_data_path.parent.mkdir(parents=True, exist_ok=True)
+    local_data_path.write_text(data)
+
+
+def hexdigest(data):
+    return hashlib.md5(data.encode('utf-8')).hexdigest()
+
+
+def get_range_prefixes():
+    data = get_local_data()
+    local_digest = hexdigest(data)
+    remote_digest = get_remote_etag()
+    if local_digest != remote_digest:
+        try:
+            data = get_remote_data()
+        except:
+            raise SystemExit('Failed to get IP ranges from AWS')
+        save_local_data(data)
+    return json.loads(data)['prefixes']

--- a/onaws/ipranges.py
+++ b/onaws/ipranges.py
@@ -41,9 +41,6 @@ def get_range_prefixes():
     local_digest = hexdigest(data)
     remote_digest = get_remote_etag()
     if local_digest != remote_digest:
-        try:
-            data = get_remote_data()
-        except:
-            raise SystemExit('Failed to get IP ranges from AWS')
+        data = get_remote_data()
         save_local_data(data)
     return json.loads(data)['prefixes']


### PR DESCRIPTION
Given the size of the AWS IP ranges file, this PR makes onaws cache it. The cache is updated when the etag header, which represents the MD5 checksum of the remote data, does not match the local data checksum. 

The local cache is located at `~/.onaws/ip-ranges.json`, and all functionality related to fetching the IP ranges has been moved to `ipranges.py`.